### PR TITLE
fix: replace proxy with coding project

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tdesign-starter-cli",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "CLI tool for TDesign Starter project",
   "main": "./src/main.ts",
   "lib": "./bin/index.js",

--- a/src/core/CoreGitDownloader.ts
+++ b/src/core/CoreGitDownloader.ts
@@ -4,21 +4,20 @@ import ora from 'ora';
 import chalk from 'chalk';
 import path from 'path';
 
-
-type SupportedTemplate = 'vue2' | 'vue3'
+type SupportedTemplate = 'vue2' | 'vue3';
 /**
  * 模板地址
  */
-const templates: Record<SupportedTemplate, { url: string, description: string, downloadUrl: string }> = {
+const templates: Record<SupportedTemplate, { url: string; description: string; downloadUrl: string }> = {
   vue2: {
     url: 'https://github.com/Tencent/tdesign-vue-starter.git',
     description: 'TDesign Vue2 Starter',
-    downloadUrl: 'github.com.cnpmjs.org:Tencent/tdesign-vue-starter#main'
+    downloadUrl: 'direct:https://tencent-tdesign.coding.net/p/starter/d/tdesign-vue-starter/git/archive/develop/?download=true'
   },
   vue3: {
     url: 'https://github.com/Tencent/tdesign-vue-next-starter.git',
     description: 'TDesign Vue3 Starter',
-    downloadUrl: 'github.com.cnpmjs.org:Tencent/tdesign-vue-next-starter#main'
+    downloadUrl: 'direct:https://tencent-tdesign.coding.net/p/starter/d/tdesign-vue-next-starter/git/archive/develop/?download=true'
   }
 };
 
@@ -26,7 +25,7 @@ const templates: Record<SupportedTemplate, { url: string, description: string, d
  * 拉取代码
  * @returns 命令行数组
  */
-export function getTemplate(options: { type: SupportedTemplate, name: string, description: string }) {
+export function getTemplate(options: { type: SupportedTemplate; name: string; description: string }) {
   console.log();
   const spinner = ora('正在构建模板...').start();
   const { downloadUrl, url } = templates[`${options.type || 'vue2'}`];

--- a/src/core/CoreInquirer.ts
+++ b/src/core/CoreInquirer.ts
@@ -33,7 +33,8 @@ export function interactionsHandler() {
 				{ name: '【Vue3】模板', value: 'vue3' }
 			],
 			default: 'vue2' // 默认值为列表项编号，起始为 0
-		}
+		},
+		
 	];
 	return inquirer.prompt(questions);
 }


### PR DESCRIPTION
### 背景 
由于国内用户访问、请求github容易出现超时、失败的问题，之前我们使用各类国内的github代理来加速用户请求。
但`github.com.cnpmjs.org`、`fastgit`等国内代理相继都失效或者停止代理了。
同时担心其他可选的代理可能也会出现失败的问题。
需要一个长期更稳定的地址来做这个代理的工作。

### 方案
- 将`starter`的项目同步到[coding](https://coding.net/)托管，并开启代码同步功能。以后长期通过coding来托管、同步starter的代码；供脚手架或后续其他场景使用。
- 替换脚手架各个下载链接为`coding`托管仓库的链接