### PR TITLE
fix: 自定义模式下自动移除无用的前部信息

### DIFF
--- a/src/core/core-options/CoreOptionsFilterForVue2.ts
+++ b/src/core/core-options/CoreOptionsFilterForVue2.ts
@@ -483,8 +483,13 @@ export class CoreOptionsFilterForVue2 implements IOptionsFilter {
 
     // console.log('replace content..', configDataContent);
 
+    // 预处理前部信息
+    const headerFlagFirstList = this.headerFlagFirst.split(";");
+    const headerFlags = headerFlagFirstList.filter((headerFlag) => configDataContent.includes(headerFlag.split(" ")[1]));
+    headerFlags.push(headerFlagFirstList.slice(-1).toString());
+
     // 保留内容 {..export default...}
-    const saveFileContent = `${this.headerFlagFirst}${headerFlag}${configDataContent}`;
+    const saveFileContent = `${headerFlags.join(";")}${headerFlag}${configDataContent}`;
 
     // 生成文件
     const elementPath = `${options.name}/src/`;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

N/A
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

在使用CLI创建自定义项目时，发现并没有自动移除未引用的资源，导致ESLint在Commit Hook 中报错，因此我修改了代码添加上了自动检测移除未引用的资源
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(CLI): 自定义模式下自动移除无用的前部信息

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
