### PR TITLE
fix: 修复lite模板没有.gitignore文件的问题

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -51,33 +51,29 @@ const defaultConfig = {
       exclude: 'node_modules/**',
       extensions
     }),
+    // 复制templates文件; 复制 .gitignore 文件；添加.npmignore文件："!.gitignore\n.npmignore"
     copy({
       targets: [
-        {
-          src: ['templates/vite/vue-lite/*', '!templates/vite/vue-lite/node_modules'],
-          dest: 'bin/templates/vite/vue-lite'
-        },
-        {
-          src: ['templates/vite/vue-next-lite/*', '!templates/vite/vue-next-lite/node_modules'],
-          dest: 'bin/templates/vite/vue-next-lite'
-        },
-        {
-          src: ['templates/vite/react-lite/*', '!templates/vite/react-lite/node_modules'],
-          dest: 'bin/templates/vite/react-lite'
-        },
-        {
-          src: ['templates/webpack/vue-lite/*', '!templates/webpack/vue-lite/node_modules'],
-          dest: 'bin/templates/webpack/vue-lite'
-        },
-        {
-          src: ['templates/webpack/vue-next-lite/*', '!templates/webpack/vue-next-lite/node_modules'],
-          dest: 'bin/templates/webpack/vue-next-lite'
-        },
-        {
-          src: ['templates/webpack/react-lite/*', '!templates/webpack/react-lite/node_modules'],
-          dest: 'bin/templates/webpack/react-lite'
-        }
-      ],
+        'templates/vite/vue-lite',
+        'templates/vite/vue-next-lite',
+        'templates/vite/react-lite',
+        'templates/webpack/vue-lite',
+        'templates/webpack/vue-next-lite',
+        'templates/webpack/react-lite'
+      ]
+        .map((filePath) => [
+          {
+            src: [`${filePath}/*`, `${filePath}/.gitignore`, `!${filePath}/node_modules`],
+            dest: `bin/${filePath}`
+          },
+          {
+            src: `${filePath}/.gitignore`,
+            dest: `bin/${filePath}`,
+            rename: '.npmignore',
+            transform: () => Buffer.from('!.gitignore\n.npmignore', 'utf-8')
+          }
+        ])
+        .flat(),
       verbose: true
     })
   ]


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#42 
https://github.com/Tencent/tdesign-starter-cli/issues/42
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
**问题**：
#### 1、运行`npm run build`命令，会复制`templates/* -> bin/templates/*`，但是不会复制 `templates/**/.gitignore`文件
解决方案：复制`templates/**/.gitignore`文件至`bin/templates/**/.gitignore`文件
#### 2、运行`npm pack`命令，构建产物不包含`templates/**/.gitignore`文件
解决方案：在每个`templates/**/.gitignore`文件同一目录下添加`.npmignore`文件，文件内容："!.gitignore\n.npmignore"
解决方案可见：https://docs.npmjs.com/cli/v9/commands/npm-publish

**效果**：
执行构建及发布命令
``` bash
npm run build && npm pack
```

```
npm notice 📦  tdesign-starter-cli@0.3.3
npm notice === Tarball Contents === 
npm notice 273B   bin/templates/vite/react-lite/.gitignore                <- add file                   
npm notice 253B   bin/templates/vite/vue-lite/.gitignore                  <- add file       
npm notice 210B   bin/templates/vite/vue-next-lite/.gitignore          <- add file           
npm notice 310B   bin/templates/webpack/react-lite/.gitignore       <- add file              
npm notice 231B   bin/templates/webpack/vue-lite/.gitignore          <- add file             
npm notice 231B   bin/templates/webpack/vue-next-lite/.gitignore <- add file
......
npm notice === Tarball Details === 
npm notice name:          tdesign-starter-cli                     
npm notice version:       0.3.3                                   
npm notice filename:      tdesign-starter-cli-0.3.3.tgz           
npm notice package size:  23.9 kB                                 
npm notice unpacked size: 209.7 kB      **(+5.7kB)**                          
npm notice shasum:        2408ad543a1c1733231215e55fb99ffd331d27f7
npm notice integrity:     sha512-s1/SjITjLpqKb[...]3Kz+rmJV0KJuw==
npm notice total files:   67  **(+6 file)**
```
**测试**：
用本地pack的包进行测试
``` bash
tar -xf tdesign-starter-cli-0.3.3.tgz && cd package && node bin/index.js init
```
构建任意lite模板
``` bash
cd test && ls -a
# .               .gitignore      assets          package.json    src 
# ..              README.md       index.html      public          vite.config.js
```


### 📝 更新日志
通过脚手架生成的"lite"模板中多了 .gitignore文件
<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->


- fix: 修复lite模板没有.gitignore文件的问题

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
