### PR TITLE
fix: fix global install vue situation

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,8 +78,7 @@
     "rimraf": "3.0.2",
     "shelljs": "^0.8.5",
     "tslib": "2.2.0",
-    "typescript": "4.2.4",
-    "vue-template-compiler": "^2.7.14"
+    "typescript": "4.2.4"
   },
   "husky": {
     "hooks": {

--- a/src/core/CoreGitDownloader.ts
+++ b/src/core/CoreGitDownloader.ts
@@ -7,7 +7,7 @@ import { SupportedTemplate, templates } from './CoreTemplate';
 import { CoreOptionsFilterForVue2, IOptionsFilter } from './core-options/CoreOptionsFilterForVue2';
 import { CoreOptionsFilterForVue3 } from './core-options/CoreOptionsFilterForVue3';
 import { CoreOptionsFilterForReact } from './core-options/CoreOptionsFilterForReact';
-import { CoreJsTransformer } from './core-js-transform/CoreJsTransformer';
+// import { CoreJsTransformer } from './core-js-transform/CoreJsTransformer';
 import rimraf from 'rimraf';
 
 export class CoreGitDownloader {
@@ -85,15 +85,15 @@ export class CoreGitDownloader {
       await optionsFilter.clearUnusedDirectories(options, finalOptions);
     }
     // JS语言版本 执行将TS模板转换为JS的处理
-    if (finalOptions.lang === 'js') {
-      const jsTransformer = new CoreJsTransformer();
+    // if (finalOptions.lang === 'js') {
+    //   const jsTransformer = new CoreJsTransformer();
 
-      await jsTransformer.transformTsFiles(options);
-      await jsTransformer.transformSfcFiles(options);
-      await jsTransformer.codeReplace(options);
-      await jsTransformer.prettierFiles(options);
-      await jsTransformer.clearTsFiles(options);
-    }
+    //   await jsTransformer.transformTsFiles(options);
+    //   await jsTransformer.transformSfcFiles(options);
+    //   await jsTransformer.codeReplace(options);
+    //   await jsTransformer.prettierFiles(options);
+    //   await jsTransformer.clearTsFiles(options);
+    // }
 
     // 执行成功相关操作
     this.executeBuildSuccess(spinner, options);


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://github.com/Tencent/tdesign-vue-next-starter/issues/619
为了支持转出js版本 此前依赖中新增了vue-template-compiler 但是不少用户全局按照了vue，版本容易发生冲突，由于转出js版本还没正式上线，暂时去掉这个依赖和相关代码 保证这些用户可以正常使用
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix: 修复全局按照vue的用户的冲突问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
