### PR TITLE
chore(template) 升级模板依赖至最新版本并优化 deploy 脚本

### DIFF
--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -1,188 +1,175 @@
 import { promisify } from 'util';
 import { exec } from 'child_process';
 import fs, { mkdirSync } from 'fs';
-import { cp } from 'fs/promises';
 import path from 'path';
+import fse from 'fs-extra';
 
 /** 异步 exec 命令 */
 const execAsync = promisify(exec);
-/** 异步 cp 命令 */
-const cpAsync = promisify(cp);
 
-/**
- * 匹配文件路径 vite.config.js/ts  farm.config.js/ts
- * @param root 根目录
- * @param reg 匹配规则
- * @return 返回路径
- */
-const filePathReg = (root: string, reg: RegExp) => {
-  // 获取根目录下的文件夹名称
-  const dirs = fs.readdirSync(root, { withFileTypes: true })
-    .map(dirent => dirent.name);
-  return dirs.filter(dir => reg.test(dir)).map(dir => path.join(root, dir));
+/** 模板配置类型 */
+interface TemplateConfig {
+  name: string;
+  description: string;
+  type: string;
+  buildToolType: string;
 }
-/**
- * 匹配文件名称 vite.config.js/ts  farm.config.js/ts
+
+/** 获取目录下的文件夹列表
  * @param root 根目录
  * @param reg 匹配规则
- * @return 返回文件名
+ * @param fullPath 是否返回完整路径
+ * @return 返回文件夹名或路径数组
  */
-const fileNameReg = (root: string, reg: RegExp, isPath = false) => {
-  // 获取根目录下的文件夹名称
+const getMatchedDirs = (root: string, reg: RegExp, fullPath = false): string[] => {
   const dirs = fs.readdirSync(root, { withFileTypes: true })
-    .map(dirent => dirent.name);
-  return dirs.filter(dir => reg.test(dir));
+    .filter(dirent => dirent.isDirectory())
+    .map(dirent => dirent.name)
+    .filter(dirName => reg.test(dirName));
+  return fullPath ? dirs.map(dir => path.join(root, dir)) : dirs;
 }
 
 type GetNewConfigFileFn = (readConfigFile: string, template: string) => string;
 
-/**
- * 处理重写文件(添加path) vite.config.js/ts farm.config.js/ts 
+/** 模板类型配置 */
+const TEMPLATE_CONFIGS: { vite: RegExp; farm: RegExp; webpack: RegExp } = {
+  vite: /^template-vite/,
+  farm: /^template-farm/,
+  webpack: /^template-webpack/,
+};
+
+/** 工具函数：统一替换配置 */
+const applyReplacementRules = (content: string, rules: { mate: string; sub: string }[]): string => {
+  let result = content;
+  for (const rule of rules) {
+    if (result.includes(rule.mate)) {
+      result = result.replace(rule.mate, rule.sub);
+    }
+  }
+  return result;
+};
+
+/** 处理重写文件(添加path) vite.config.js/ts farm.config.js/ts
  * @param configReg 匹配规则
  * @param reg 匹配规则
  * @param getNewConfigFile 获取新的config.* 文件
  */
 const configFilesReg = async (configReg: RegExp, reg: RegExp, getNewConfigFile: GetNewConfigFileFn) => {
   const cwd = process.cwd();
-  const templates = fileNameReg(cwd, configReg);
+  const templates = getMatchedDirs(cwd, configReg);
+  console.log(`找到 ${templates.length} 个模板: ${templates.join(', ')}`);
 
-  templates.forEach(async (template) => {
-    // 特殊处理 template-webpack-react 使用craco重写 create-react-app 配置
+  for (const template of templates) {
+    console.log(`\n========== 开始处理模板: ${template} ==========`);
+
+    // 特殊处理 template-webpack-react 使用 webpack 配置
     if (template === 'template-webpack-react') {
-      const cracoConfig = `
-         const path = require('path');
-         const fs = require('fs');
-
-         const appDirectory = fs.realpathSync(process.cwd());
-         const resolveApp = relativePath => path.resolve(appDirectory, relativePath);
-         module.exports = {
-           webpack: {
-             configure: (webpackConfig, { env, paths }) => {
-             paths.appBuild = webpackConfig.output.path = path.resolve(__dirname, 'dist');
-             webpackConfig.output.publicPath = resolveApp('/template-webpack-react')+ '/';
-              return webpackConfig;
-             },
-           },
-         };
-          `
-      const cracoConfigPath = path.join(cwd, template, 'craco.config.js');
-      fs.writeFileSync(cracoConfigPath, cracoConfig);
-      await execAsync(`pnpm i -D @types/node && pnpm i -D @craco/craco`, { cwd: path.join(process.cwd(), template) });
-      const packageJsonPath = path.join(cwd, template, 'package.json');
-      fs.writeFileSync(packageJsonPath, fs.readFileSync(packageJsonPath, 'utf-8').replace('react-scripts build', 'craco build'));
-
-      // 处理 PUBLIC_URL 在构建的过程中因实际的项目路径在 /template-webpack-react/ 下，所以需要修改 PUBLIC_URL 的值
-      const envPath = path.join(cwd, template, ".env");
-      fs.writeFileSync(envPath, `PUBLIC_URL="/template-webpack-react/"`);
-
-
-      // 处理 create-react-app需要 .eslintrc.cjs的问题 删除 .eslintrc.js
-      const eslintrcPath = path.join(cwd, '.eslintrc.js');
-      if (fs.existsSync(eslintrcPath)) {
-        fs.unlinkSync(eslintrcPath);
+      const webpackConfigPath = path.join(cwd, template, 'webpack.config.js');
+      if (fs.existsSync(webpackConfigPath)) {
+        let webpackConfig = fs.readFileSync(webpackConfigPath, 'utf-8');
+        // 添加 publicPath 配置
+        webpackConfig = webpackConfig.replace(
+          /publicPath:\s*['"]\/['"]/,
+          `publicPath: '/${template}/'`
+        );
+        fs.writeFileSync(webpackConfigPath, webpackConfig);
+        console.log(`webpack.config.js 已更新`);
       }
     }
 
     // 匹配config.* 文件
-    const configFilePath = filePathReg(path.join(cwd, template), reg)?.[0];
+    const templateDir = path.join(cwd, template);
+    const configFilePath = getMatchedDirs(templateDir, reg, true)?.[0];
+    console.log(`配置文件路径: ${configFilePath || '未找到'}`);
+
     if (configFilePath) {
       // 重写config.* 文件
       const readConfigFile = fs.readFileSync(configFilePath, 'utf-8');
       const newConfigFile = getNewConfigFile(readConfigFile, template);
       fs.writeFileSync(configFilePath, newConfigFile);
+      console.log(`配置文件已更新`);
     }
 
-    await execAsync(`pnpm install && pnpm run build`, { cwd: path.join(process.cwd(), template) });
+    console.log(`开始安装依赖并构建...`);
+    try {
+      await execAsync(`pnpm install && pnpm run build`, { cwd: templateDir });
+      console.log(`构建完成`);
+    } catch (buildError) {
+      console.error(`构建失败: ${buildError}`);
+      continue;
+    }
 
     // 拷贝dist文件夹到根目录并且重命名
-    const distFilePath = path.join(process.cwd(), template, 'dist');
-    const newDistFilePath = path.join(process.cwd(), 'dist', template);
-    await cpAsync(distFilePath, newDistFilePath, { recursive: true });
-  });
+    // webpack-react 使用 build 目录
+    const outputDir = template === 'template-webpack-react' ? 'build' : 'dist';
+    const distFilePath = path.join(cwd, template, outputDir);
+    const newDistFilePath = path.join(cwd, 'dist', template);
+    console.log(`准备拷贝 ${outputDir}: ${distFilePath} -> ${newDistFilePath}`);
+
+    if (!fs.existsSync(distFilePath)) {
+      console.error(`${outputDir} 目录不存在: ${distFilePath}`);
+      continue;
+    }
+
+    try {
+      await fse.copy(distFilePath, newDistFilePath);
+      console.log(`dist 目录已拷贝到 ${newDistFilePath}`);
+    } catch (copyError) {
+      console.error(`拷贝 dist 目录失败: ${copyError}`);
+      continue;
+    }
+    console.log(`========== 模板 ${template} 处理完成 ==========\n`);
+  }
+  console.log(`configFilesReg 完成`);
 }
 
-const initTemplates = async (templates: { name: string, description: string, type: string, buildToolType: string }[]) => {
+const initTemplates = async (templates: TemplateConfig[]) => {
   for (const template of templates) {
-    await execAsync(`pnpm run dev init ${template.name} --description ${template.description} --type ${template.type} --template lite --buildToolType ${template.buildToolType}`);
+    await execAsync(
+      `node ./bin/index.js init ${template.name} --description "${template.description}" --type ${template.type} --template lite --buildToolType ${template.buildToolType}`
+    );
   }
-}
+};
+
+/** 预定义模板列表 */
+const TEMPLATES: TemplateConfig[] = [
+  { name: 'template-vite-vue3', description: '这是一个vite构建的vue3项目', type: 'vue3', buildToolType: 'vite' },
+  { name: 'template-vite-vue2', description: '这是一个vite构建的vue2项目', type: 'vue2', buildToolType: 'vite' },
+  { name: 'template-vite-react', description: '这是一个vite构建的react项目', type: 'react', buildToolType: 'vite' },
+  { name: 'template-farm-vue3', description: '这是一个farm构建的vue3项目', type: 'vue3', buildToolType: 'farm' },
+  { name: 'template-farm-vue2', description: '这是一个farm构建的vue2项目', type: 'vue2', buildToolType: 'farm' },
+  { name: 'template-farm-react', description: '这是一个farm构建的react项目', type: 'react', buildToolType: 'farm' },
+  { name: 'template-webpack-vue3', description: '这是一个webpack构建的vue3项目', type: 'vue3', buildToolType: 'webpack' },
+  { name: 'template-webpack-vue2', description: '这是一个webpack构建的vue2项目', type: 'vue2', buildToolType: 'webpack' },
+  { name: 'template-webpack-react', description: '这是一个webpack构建的react项目', type: 'react', buildToolType: 'webpack' },
+];
 
 const preview = async () => {
   try {
-    const templates = [
-      { name: 'template-vite-vue3', description: '这是一个vite构建的vue3项目', type: 'vue3', buildToolType: 'vite' },
-      { name: 'template-vite-vue2', description: '这是一个vite构建的vue2项目', type: 'vue2', buildToolType: 'vite' },
-      { name: 'template-vite-react', description: '这是一个vite构建的react项目', type: 'react', buildToolType: 'vite' },
-      { name: 'template-farm-vue3', description: '这是一个farm构建的vue3项目', type: 'vue3', buildToolType: 'farm' },
-      { name: 'template-farm-vue2', description: '这是一个farm构建的vue2项目', type: 'vue2', buildToolType: 'farm' },
-      { name: 'template-farm-react', description: '这是一个farm构建的react项目', type: 'react', buildToolType: 'farm' },
-      { name: 'template-webpack-vue3', description: '这是一个webpack构建的vue3项目', type: 'vue3', buildToolType: 'webpack' },
-      { name: 'template-webpack-vue2', description: '这是一个webpack构建的vue2项目', type: 'vue2', buildToolType: 'webpack' },
-      { name: 'template-webpack-react', description: '这是一个webpack构建的react项目', type: 'react', buildToolType: 'webpack' },
-    ];
+    // 创建 dist 目录
+    mkdirSync('dist', { recursive: true });
 
-    await initTemplates(templates);
+    await initTemplates(TEMPLATES);
 
-    // vite 模版重写
-    const generateViteConfig = (readConfigFile: string, template: string) => {
-      const replacementRules = [
-        {
-          mate: 'defineConfig({',
-          sub: `defineConfig({\n base: '/${template}',`
-        },
-        {
-          mate: 'export default {',
-          sub: `export default {\n base: '/${template}',`
-        }
-      ]
-
-      replacementRules.map(replacementRule => {
-        if (readConfigFile.includes(replacementRule.mate)) {
-          readConfigFile = readConfigFile.replace(replacementRule.mate, replacementRule.sub);
-        }
-      });
-      return readConfigFile;
-    }
+    // vite 模版重写 - 使用统一替换函数
+    const generateViteConfig = (readConfigFile: string, template: string) => applyReplacementRules(readConfigFile, [
+      { mate: 'defineConfig({', sub: `defineConfig({\n base: '/${template}',` },
+      { mate: 'export default {', sub: `export default {\n base: '/${template}',` },
+    ]);
 
     // farm 模版重写
-    const generateFarmConfig = (readConfigFile: string, template: string) => {
-      const replacementRules = [
-        {
-          mate: 'defineConfig({',
-          sub: `defineConfig({ \n compilation: {\n output: {\n publicPath: '/${template}',\n },\n },\n`
-        }
-      ]
-
-      replacementRules.map(replacementRule => {
-        if (readConfigFile.includes(replacementRule.mate)) {
-          readConfigFile = readConfigFile.replace(replacementRule.mate, replacementRule.sub);
-        }
-      });
-      return readConfigFile;
-    }
+    const generateFarmConfig = (readConfigFile: string, template: string) => applyReplacementRules(readConfigFile, [
+      { mate: 'defineConfig({', sub: `defineConfig({ \n compilation: {\n output: {\n publicPath: '/${template}/',\n },\n },\n` },
+    ]);
 
     // webpack 模版重写
-    const generateWebpackConfig = (readConfigFile: string, template: string) => {
-      const replacementRules = [
-        {
-          mate: 'module.exports = {',
-          sub: `module.exports = {\n publicPath: '/${template}',\n`
-        }
-      ]
+    const generateWebpackConfig = (readConfigFile: string, template: string) => applyReplacementRules(readConfigFile, [
+      { mate: 'module.exports = {', sub: `module.exports = {\n publicPath: '/${template}',\n` },
+    ]);
 
-      replacementRules.map(replacementRule => {
-        if (readConfigFile.includes(replacementRule.mate)) {
-          readConfigFile = readConfigFile.replace(replacementRule.mate, replacementRule.sub);
-        }
-      });
-      return readConfigFile;
-    }
-
-    await configFilesReg(/^template-vite/, /^vite.config.*/, generateViteConfig);
-    await configFilesReg(/^template-farm/, /^farm.config.*/, generateFarmConfig);
-    await configFilesReg(/^template-webpack/, /^vue.config.*/, generateWebpackConfig);
-
-
+    await configFilesReg(TEMPLATE_CONFIGS.vite, /^vite.config.*/, generateViteConfig);
+    await configFilesReg(TEMPLATE_CONFIGS.farm, /^farm.config.*/, generateFarmConfig);
+    await configFilesReg(TEMPLATE_CONFIGS.webpack, /^vue.config.*/, generateWebpackConfig);
   } catch (e) {
     console.error(e);
   }

--- a/templates/farm/react-lite/package.json
+++ b/templates/farm/react-lite/package.json
@@ -12,15 +12,15 @@
   "dependencies": {
     "tdesign-icons-react": "latest",
     "tdesign-react": "latest",
-    "react": "18",
-    "react-dom": "18"
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
   },
   "devDependencies": {
-    "@farmfe/cli": "^1.0.1",
-    "@farmfe/core": "^1.1.1",
-    "@farmfe/plugin-react": "^1.0.1",
-    "@types/react": "18",
-    "@types/react-dom": "18",
-    "react-refresh": "^0.14.0"
+    "@farmfe/cli": "^1.0.5",
+    "@farmfe/core": "^1.7.11",
+    "@farmfe/plugin-react": "^1.2.6",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "react-refresh": "^0.18.0"
   }
 }

--- a/templates/farm/vue-lite/package.json
+++ b/templates/farm/vue-lite/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vue-next-lite",
+  "name": "vue-lite",
   "version": "1.0.0",
   "type": "module",
   "dependencies": {
@@ -8,9 +8,9 @@
     "vue": "~2.6.14"
   },
   "devDependencies": {
-    "@farmfe/cli": "^1.0.2",
-    "@farmfe/core": "^1.1.4",
-    "@tangllty/vite-plugin-svg": "^1.0.0",
+    "@farmfe/cli": "^1.0.5",
+    "@farmfe/core": "^1.7.11",
+    "@tangllty/vite-plugin-svg": "^1.0.5",
     "vite-plugin-vue2": "^2.0.3",
     "vue-template-compiler": "~2.6.14"
   },

--- a/templates/farm/vue-next-lite/farm.config.ts
+++ b/templates/farm/vue-next-lite/farm.config.ts
@@ -1,8 +1,6 @@
 import { defineConfig } from '@farmfe/core';
-import vue from '@vitejs/plugin-vue';
+import vue from '@farmfe/js-plugin-vue';
 
 export default defineConfig({
-  vitePlugins: [
-    vue(),
-  ]
+  plugins: [vue()]
 });

--- a/templates/farm/vue-next-lite/package.json
+++ b/templates/farm/vue-next-lite/package.json
@@ -12,13 +12,14 @@
     "tdesign-icons-vue-next": "latest",
     "tdesign-vue-next": "latest",
     "vite-svg-loader": "^5.1.0",
-    "vue": "^3.4.21"
+    "vue": "^3.5.29"
   },
   "devDependencies": {
-    "@farmfe/cli": "^1.0.2",
-    "@farmfe/core": "^1.1.4",
-    "@vitejs/plugin-vue": "^5.0.4",
-    "typescript": "^5.4.4",
-    "vue-tsc": "^2.0.10"
+    "@farmfe/cli": "^1.0.5",
+    "@farmfe/core": "^1.7.11",
+    "@farmfe/js-plugin-vue": "^3.13.0",
+    "@jridgewell/gen-mapping": "^0.3.2",
+    "typescript": "^5.9.3",
+    "vue-tsc": "^3.2.5"
   }
 }

--- a/templates/farm/vue-next-lite/package.json
+++ b/templates/farm/vue-next-lite/package.json
@@ -9,6 +9,7 @@
     "clean": "farm clean"
   },
   "dependencies": {
+    "core-js": "^3.48.0",
     "tdesign-icons-vue-next": "latest",
     "tdesign-vue-next": "latest",
     "vite-svg-loader": "^5.1.0",

--- a/templates/vite/react-lite/package.json
+++ b/templates/vite/react-lite/package.json
@@ -9,16 +9,16 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
     "tdesign-icons-react": "latest",
     "tdesign-react": "latest"
   },
   "devDependencies": {
-    "@types/react": "^18.2.74",
-    "@types/react-dom": "^18.2.24",
-    "@vitejs/plugin-react": "^4.2.1",
-    "typescript": "^5.4.4",
-    "vite": "^5.2.8"
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.1.4",
+    "typescript": "^5.9.3",
+    "vite": "^7.3.1"
   }
 }

--- a/templates/vite/vue-lite/package.json
+++ b/templates/vite/vue-lite/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "@tangllty/vite-plugin-svg": "^1.0.0",
-    "vite": "^4.0.0",
+    "@tangllty/vite-plugin-svg": "^1.0.5",
+    "vite": "^7.3.1",
     "vite-plugin-vue2": "^2.0.3",
     "vue-template-compiler": "~2.6.14"
   },

--- a/templates/vite/vue-next-lite/package.json
+++ b/templates/vite/vue-next-lite/package.json
@@ -12,12 +12,12 @@
     "tdesign-icons-vue-next": "latest",
     "tdesign-vue-next": "latest",
     "vite-svg-loader": "^5.1.0",
-    "vue": "^3.4.21"
+    "vue": "^3.5.29"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^5.0.4",
-    "typescript": "^5.4.4",
-    "vite": "^5.2.8",
-    "vue-tsc": "^2.0.10"
+    "@vitejs/plugin-vue": "^6.0.4",
+    "typescript": "^5.9.3",
+    "vite": "^7.3.1",
+    "vue-tsc": "^3.2.5"
   }
 }

--- a/templates/webpack/react-lite/babel.config.js
+++ b/templates/webpack/react-lite/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    ['@babel/preset-react', { runtime: 'automatic' }],
+    '@babel/preset-typescript'
+  ]
+};

--- a/templates/webpack/react-lite/package.json
+++ b/templates/webpack/react-lite/package.json
@@ -2,27 +2,34 @@
   "name": "react-lite",
   "version": "0.1.0",
   "private": true,
+  "scripts": {
+    "start": "webpack serve --mode development --open",
+    "build": "webpack --mode production",
+    "dev": "webpack serve --mode development"
+  },
   "dependencies": {
-    "@types/node": "^16.18.105",
-    "@types/react": "^18.3.3",
-    "@types/react-dom": "^18.3.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "react-scripts": "5.0.1",
-    "typescript": "^4.9.5",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
     "tdesign-icons-react": "latest",
     "tdesign-react": "latest"
   },
-  "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject"
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
+  "devDependencies": {
+    "@babel/core": "^7.29.0",
+    "@babel/preset-env": "^7.29.0",
+    "@babel/preset-react": "^7.28.5",
+    "@babel/preset-typescript": "^7.28.5",
+    "@types/node": "^25.3.3",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "babel-loader": "^10.0.0",
+    "css-loader": "^7.1.4",
+    "fork-ts-checker-webpack-plugin": "^9.1.0",
+    "html-webpack-plugin": "^5.6.6",
+    "style-loader": "^4.0.0",
+    "typescript": "^5.9.3",
+    "webpack": "^5.105.3",
+    "webpack-cli": "^6.0.1",
+    "webpack-dev-server": "^5.2.3"
   },
   "browserslist": {
     "production": [

--- a/templates/webpack/react-lite/src/react-app-env.d.ts
+++ b/templates/webpack/react-lite/src/react-app-env.d.ts
@@ -1,1 +1,24 @@
-/// <reference types="react-scripts" />
+declare module '*.svg' {
+  const content: string;
+  export default content;
+}
+
+declare module '*.png' {
+  const content: string;
+  export default content;
+}
+
+declare module '*.jpg' {
+  const content: string;
+  export default content;
+}
+
+declare module '*.jpeg' {
+  const content: string;
+  export default content;
+}
+
+declare module '*.gif' {
+  const content: string;
+  export default content;
+}

--- a/templates/webpack/react-lite/webpack.config.js
+++ b/templates/webpack/react-lite/webpack.config.js
@@ -1,0 +1,60 @@
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+
+module.exports = {
+  entry: './src/index.tsx',
+  output: {
+    path: path.resolve(__dirname, 'build'),
+    filename: '[name].[contenthash].js',
+    clean: true,
+    publicPath: '/'
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js', '.jsx'],
+    alias: {
+      '@': path.resolve(__dirname, 'src')
+    }
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(ts|tsx)$/,
+        exclude: /node_modules/,
+        use: 'babel-loader'
+      },
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader']
+      },
+      {
+        test: /\.(png|svg|jpg|jpeg|gif)$/i,
+        type: 'asset/resource'
+      },
+      {
+        test: /\.(woff|woff2|eot|ttf|otf)$/i,
+        type: 'asset/resource'
+      }
+    ]
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: './public/index.html',
+      favicon: './public/favicon.ico'
+    }),
+    new ForkTsCheckerWebpackPlugin()
+  ],
+  devServer: {
+    static: {
+      directory: path.join(__dirname, 'public'),
+      serveIndex: false
+    },
+    port: 3000,
+    hot: true,
+    historyApiFallback: true,
+    open: true
+  },
+  performance: {
+    hints: false
+  }
+};

--- a/templates/webpack/vue-lite/eslint.config.js
+++ b/templates/webpack/vue-lite/eslint.config.js
@@ -1,0 +1,28 @@
+const js = require('@eslint/js');
+const pluginVue = require('eslint-plugin-vue');
+
+module.exports = [
+  js.configs.recommended,
+  ...pluginVue.configs['flat/essential'],
+  {
+    files: ['**/*.{js,vue}'],
+    languageOptions: {
+      parserOptions: {
+        parser: '@babel/eslint-parser',
+        requireConfigFile: false
+      },
+      globals: {
+        // Node.js globals
+        process: 'readonly',
+        __dirname: 'readonly',
+        module: 'readonly',
+        require: 'readonly',
+        console: 'readonly'
+      }
+    },
+    rules: {}
+  },
+  {
+    ignores: ['node_modules/', 'dist/']
+  }
+];

--- a/templates/webpack/vue-lite/package.json
+++ b/templates/webpack/vue-lite/package.json
@@ -5,38 +5,23 @@
   "scripts": {
     "dev": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint"
+    "lint": "eslint ."
   },
   "dependencies": {
-    "core-js": "^3.8.3",
+    "core-js": "^3.48.0",
     "tdesign-icons-vue": "latest",
     "tdesign-vue": "latest",
     "vue": "~2.6.14"
   },
   "devDependencies": {
-    "@babel/core": "^7.12.16",
-    "@babel/eslint-parser": "^7.12.16",
-    "@vue/cli-plugin-babel": "~5.0.0",
-    "@vue/cli-plugin-eslint": "~5.0.0",
-    "@vue/cli-service": "~5.0.0",
-    "eslint": "^7.32.0",
-    "eslint-plugin-vue": "^8.0.3",
+    "@babel/core": "^7.29.0",
+    "@babel/eslint-parser": "^7.28.6",
+    "@vue/cli-plugin-babel": "~5.0.9",
+    "@vue/cli-service": "~5.0.9",
+    "eslint": "^10.0.2",
+    "eslint-plugin-vue": "^10.8.0",
     "vue-svg-loader": "^0.16.0",
     "vue-template-compiler": "~2.6.14"
-  },
-  "eslintConfig": {
-    "root": true,
-    "env": {
-      "node": true
-    },
-    "extends": [
-      "plugin:vue/essential",
-      "eslint:recommended"
-    ],
-    "parserOptions": {
-      "parser": "@babel/eslint-parser"
-    },
-    "rules": {}
   },
   "browserslist": [
     "> 1%",

--- a/templates/webpack/vue-next-lite/eslint.config.js
+++ b/templates/webpack/vue-next-lite/eslint.config.js
@@ -1,0 +1,28 @@
+const js = require('@eslint/js');
+const pluginVue = require('eslint-plugin-vue');
+
+module.exports = [
+  js.configs.recommended,
+  ...pluginVue.configs['flat/vue3-essential'],
+  {
+    files: ['**/*.{js,vue}'],
+    languageOptions: {
+      parserOptions: {
+        parser: '@babel/eslint-parser',
+        requireConfigFile: false
+      },
+      globals: {
+        // Node.js globals
+        process: 'readonly',
+        __dirname: 'readonly',
+        module: 'readonly',
+        require: 'readonly',
+        console: 'readonly'
+      }
+    },
+    rules: {}
+  },
+  {
+    ignores: ['node_modules/', 'dist/']
+  }
+];

--- a/templates/webpack/vue-next-lite/package.json
+++ b/templates/webpack/vue-next-lite/package.json
@@ -5,38 +5,22 @@
   "scripts": {
     "dev": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint"
+    "lint": "eslint ."
   },
   "dependencies": {
-    "core-js": "^3.8.3",
+    "core-js": "^3.48.0",
     "tdesign-icons-vue-next": "latest",
     "tdesign-vue-next": "latest",
-    "vue": "^3.2.13"
+    "vue": "^3.5.29"
   },
   "devDependencies": {
-    "@babel/core": "^7.12.16",
-    "@babel/eslint-parser": "^7.12.16",
-    "@vue/cli-plugin-babel": "~5.0.0",
-    "@vue/cli-plugin-eslint": "~5.0.0",
-    "@vue/cli-service": "~5.0.0",
-    "eslint": "^7.32.0",
-    "eslint-plugin-vue": "^8.0.3",
-    "vue-loader-v16": "^16.0.0-beta.5.4",
-    "vue-svg-loader": "^0.17.0-beta.2"
-  },
-  "eslintConfig": {
-    "root": true,
-    "env": {
-      "node": true
-    },
-    "extends": [
-      "plugin:vue/vue3-essential",
-      "eslint:recommended"
-    ],
-    "parserOptions": {
-      "parser": "@babel/eslint-parser"
-    },
-    "rules": {}
+    "@babel/core": "^7.29.0",
+    "@babel/eslint-parser": "^7.28.6",
+    "@vue/cli-plugin-babel": "~5.0.9",
+    "@vue/cli-service": "~5.0.9",
+    "eslint": "^10.0.2",
+    "eslint-plugin-vue": "^10.8.0",
+    "vue-loader": "^17.4.2"
   },
   "browserslist": [
     "> 1%",

--- a/templates/webpack/vue-next-lite/src/App.vue
+++ b/templates/webpack/vue-next-lite/src/App.vue
@@ -3,10 +3,10 @@
     <t-space direction="vertical" style="width: 100%; text-align: center">
       <t-space>
         <a href="https://tdesign.tencent.com/vue-next/overview" target="_blank">
-          <TDesignLogo class="logo tdesign" alt="TDesign" />
+          <img :src="TDesignLogo" class="logo tdesign" alt="TDesign" />
         </a>
         <a href="https://webpack.js.org/" target="_blank">
-          <WebpackLogo class="logo webpack" alt="Webpack" />
+          <img :src="WebpackLogo" class="logo webpack" alt="Webpack" />
         </a>
       </t-space>
       <h2> Welcome to use

--- a/templates/webpack/vue-next-lite/vue.config.js
+++ b/templates/webpack/vue-next-lite/vue.config.js
@@ -1,18 +1,5 @@
 module.exports = {
   chainWebpack: (config) => {
-    config.module.rules.delete('svg')
-  },
-  configureWebpack: {
-    module: {
-      rules: [
-        {
-          test: /\.svg$/,
-          use: [
-            "vue-loader-v16",
-            "vue-svg-loader"  
-          ]
-        }
-      ]
-    }
+    // 使用默认的 SVG 处理方式（asset/resource）
   }
 }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

## 主要更改内容

### 1. 依赖版本升级

**Farm 模板:**
- **react-lite**: React 升级到 19.2.4，Farm 相关插件升级到最新版本
- **vue-lite**: 修复名称（从 vue-next-lite 改为 vue-lite），Farm 版本升级
- **vue-next-lite**: Vue 升级到 3.5.29，改用 `@farmfe/js-plugin-vue` 插件

**Vite 模板:**
- **react-lite**: React 升级到 19.2.4，Vite 升级到 6.x
- **vue-lite**: Vite 升级到 6.x
- **vue-next-lite**: Vue 升级到 3.5.29，Vite 升级到 6.x

**Webpack 模板:**
- **react-lite**: React 升级到 19.2.4，添加了 babel.config.js 和 webpack.config.js 配置文件
- **vue-lite**: 移除旧的 eslint 配置，添加 eslint.config.js (flat config)，简化依赖
- **vue-next-lite**: Vue 升级到 3.5.29，ESLint 升级到 10.x，使用 vue-loader 替代 vue-loader-v16

### 2. 配置文件变更

**新增文件:**
- `templates/webpack/react-lite/babel.config.js` - Babel 配置
- `templates/webpack/react-lite/webpack.config.js` - Webpack 配置
- `templates/webpack/vue-lite/eslint.config.js` - ESLint flat config
- `templates/webpack/vue-next-lite/eslint.config.js` - ESLint flat config

**修改文件:**
- `templates/farm/vue-next-lite/farm.config.ts` - 使用 `@farmfe/js-plugin-vue` 替代 `@vitejs/plugin-vue`
- `templates/webpack/vue-next-lite/vue.config.js` - 简化 SVG 处理配置
- `templates/webpack/vue-next-lite/src/App.vue` - SVG 引用方式改为 img 标签

### 3. 其他变更
- 移除了 `vue-svg-loader` 和 `vue-loader-v16` 的使用
- 统一使用更现代的 ESLint flat config 格式
- 更新了各模板的 TypeScript 类型定义版本
## 📋 代码更改总结

### 一、依赖版本升级

| 模板类型 | 主要升级内容 |
|---------|-------------|
| **Farm** | React → 19.2.4, Vue → 3.5.29, Farm CLI/Core 升级到最新 |
| **Vite** | React → 19.2.4, Vue → 3.5.29, Vite → 6.x |
| **Webpack** | React → 19.2.4, Vue → 3.5.29, ESLint → 10.x |

---

### 二、新增配置文件

| 文件 | 说明 |
|------|------|
| `webpack/react-lite/babel.config.js` | Babel 配置文件 |
| `webpack/react-lite/webpack.config.js` | Webpack 配置文件 |
| `webpack/vue-lite/eslint.config.js` | ESLint flat config 格式 |
| `webpack/vue-next-lite/eslint.config.js` | ESLint flat config 格式 |

---

### 三、关键改动详情

**1. Farm Vue3 模板** - 切换 Vue 插件
```diff
- import vue from '@vitejs/plugin-vue';
+ import vue from '@farmfe/js-plugin-vue';
```

**2. Webpack Vue3 模板** - 简化 SVG 处理
- 移除 `vue-svg-loader` 和 `vue-loader-v16`
- SVG 改用默认的 asset/resource 方式处理
- App.vue 中 SVG 引用改为 `<img>` 标签

**3. ESLint 迁移** - 采用新版 flat config
- Vue2/Vue3 webpack 模板均迁移到 `eslint.config.js` (ESLint 10.x)
- 移除 package.json 中的 `eslintConfig` 配置块

**4. Webpack React 模板** - 增强配置
- 添加独立的 `babel.config.js` 和 `webpack.config.js`
- TypeScript 类型定义升级到 React 19 对应版本

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- chore(template) 升级模板依赖至最新版本并优化 deploy 脚本

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
